### PR TITLE
Add TupleAsArgs for using multiple arguments in Sequential.

### DIFF
--- a/src/torchestra/__init__.py
+++ b/src/torchestra/__init__.py
@@ -53,6 +53,9 @@ from ._pipes import (
     Sequential as Sequential,
 )
 from ._pipes import (
+    TupleAsArgs as TupleAsArgs,
+)
+from ._pipes import (
     field_modules as field_modules,
 )
 from ._sparse_slices import (

--- a/src/torchestra/_stats_plan.py
+++ b/src/torchestra/_stats_plan.py
@@ -3,7 +3,7 @@ from typing import Dict, Iterable, List, OrderedDict, Set, Tuple
 
 import torch
 
-from ._pipes import Parallel, Sequential
+from ._pipes import Parallel, Sequential, TupleAsArgs
 
 STATS_PLAN_INPUT_MAPPING_ALL = -1
 STATS_PLAN_INPUT_MAPPING_BYPASS = -2
@@ -28,6 +28,8 @@ class StatsPlan:
         if isinstance(module, Parallel) or isinstance(module, Sequential):
             for i, m in enumerate(module):
                 yield from self._find_stats_modules(m, f"{path}.{i}" if path else str(i))
+        elif isinstance(module, TupleAsArgs):
+            yield from self._find_stats_modules(module.inner, f"{path}.inner" if path else "inner")
 
         if hasattr(module, "calculate_stats") and hasattr(module, "combine_stats") and hasattr(module, "apply_stats"):
             yield path


### PR DESCRIPTION
This is a rudimentary implementation to be able to use multi-argument modules in the middle of a Sequential module.

What's not covered yet is the ability to have a `Sequential` or `Parallel` inside a `TupleAsDict`. This would require slightly bigger changes to `StatsPlan` for now, and it's better to fit those together with the upcoming potentially breaking changes to support shared stats modules (allowing built-in support for example for having a shared lookup table for multiple inputs) and custom stage splitting strategies (for example to split memory-hungry lookup calculations into their own parallel stages).

The limitation is in any case niche and about ergonomy, `TupleAsArgs(Parallel(x))` can be rewritten as `Parallel(TupleAsArgs(_x) for _x in x) and `TupleAsArgs(Sequential(x, y))` can be rewritten as `Sequential(TupleAsArgs(x), y)`.