### PR TITLE
Fix IndexLookup for empty inputs.

### DIFF
--- a/src/torchestra/_lookups.py
+++ b/src/torchestra/_lookups.py
@@ -217,7 +217,7 @@ class IndexLookup(torch.nn.Module):
             taken.add(i)
 
     def forward(self, x: List[str]) -> torch.Tensor:
-        return torch.tensor([self.lookup.get(_x, self.unknown_idx) for _x in x])
+        return torch.tensor([self.lookup.get(_x, self.unknown_idx) for _x in x], dtype=torch.int64)
 
 
 class IntCountLookup(torch.nn.Module):

--- a/src/torchestra/test_lookups.py
+++ b/src/torchestra/test_lookups.py
@@ -256,6 +256,15 @@ def test_index_lookup_eliminator():
     assert all(module(["a", "b", "c", "d", "e", "f"]) == torch.tensor([2, 3, 1, 1, 1, 1]))
 
 
+def test_index_lookup_empty_input():
+    module = IndexLookup()
+
+    received = module([])
+
+    assert received.dtype == torch.int64
+    assert all(received == torch.tensor([], dtype=torch.int64))
+
+
 def test_int_count_lookup():
     module = IntCountLookup()
     stats1 = module.calculate_stats(torch.tensor([1, 2, 1, -3, 1, 2, 4, 1, 2, -3, 1, 2, 4]))


### PR DESCRIPTION
Currently the `IndexLookup` will return a tensor of type `torch.float32` if it's called with an empty list of strings. This PR fixes the module to consistently return a tensor of type `torch.int64`.