### PR TITLE
Support override opts for NanToNum.

### DIFF
--- a/src/torchestra/_wrappers.py
+++ b/src/torchestra/_wrappers.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import torch
 
@@ -44,10 +44,21 @@ class NanToNum(torch.nn.Module):
     Replaces NaN values in a tensor with zeros.
 
     This is a simple wrapper around `torch.nan_to_num` to expose it as a composable module.
+
+    Args:
+        nan: The value with which to replace NaN values.
+        posinf: The value with which to replace positive infinity values.
+        neginf: The value with which to replace negative infinity values.
     """
 
+    def __init__(self, nan: Optional[float] = 0.0, posinf: Optional[float] = None, neginf: Optional[float] = None):
+        super().__init__()
+        self.nan = nan
+        self.posinf = posinf
+        self.neginf = neginf
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x.nan_to_num()
+        return x.nan_to_num(nan=self.nan, posinf=self.posinf, neginf=self.neginf)
 
 
 class Clamp(torch.nn.Module):

--- a/src/torchestra/test_wrappers.py
+++ b/src/torchestra/test_wrappers.py
@@ -23,11 +23,50 @@ def test_cat():
 
 def test_nan_to_num():
     module = NanToNum()
+    jit_module = torch.jit.script(module)
     x = torch.tensor([1, 2, float("nan"), 4])
 
     received = module(x)
+    jit_received = jit_module(x)
 
     assert torch.equal(received, torch.tensor([1, 2, 0, 4]))
+    assert torch.equal(jit_received, torch.tensor([1, 2, 0, 4]))
+
+
+def test_nan_to_num_nan_override():
+    module = NanToNum(nan=5.0)
+    jit_module = torch.jit.script(module)
+    x = torch.tensor([1, 2, float("nan"), 4])
+
+    received = module(x)
+    jit_received = jit_module(x)
+
+    assert torch.equal(received, torch.tensor([1, 2, 5, 4]))
+    assert torch.equal(jit_received, torch.tensor([1, 2, 5, 4]))
+
+
+def test_nan_to_num_posinf_override():
+    module = NanToNum(posinf=5.0)
+    jit_module = torch.jit.script(module)
+    x = torch.tensor([1, 2, float("inf"), 4])
+
+    received = module(x)
+    jit_received = jit_module(x)
+
+    assert torch.equal(received, torch.tensor([1, 2, 5, 4]))
+    assert torch.equal(jit_received, torch.tensor([1, 2, 5, 4]))
+
+
+def test_nan_to_num_neginf_override():
+    module = NanToNum(neginf=5.0)
+    jit_module = torch.jit.script(module)
+    x = torch.tensor([1, 2, float("-inf"), 4])
+
+    received = module(x)
+    jit_received = jit_module(x)
+
+    assert torch.equal(received, torch.tensor([1, 2, 5, 4]))
+    assert torch.equal(jit_received, torch.tensor([1, 2, 5, 4]))
 
 
 def test_clamp():


### PR DESCRIPTION
`torch.nan_to_num` supports specifying `nan`, `posinf` and `neginf` overrides. This PR adds that functionality to `torchestra.NanToNum` as well.